### PR TITLE
Fix linting issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,4 +49,4 @@ deps =
     flake8-commas
 commands =
     - isort --check-only --recursive {toxinidir}/src setup.py
-    flake8 --doctests src tests setup.py {posargs}
+    flake8 --doctests src setup.py {posargs}


### PR DESCRIPTION
... which arise with the new flake8 version.

`tests` is no longer a valid flake8 param, as it is no top level
directory.

As it is a subfolder of the `src` folder, it gets linted anyway.

modified:   tox.ini